### PR TITLE
Políticas de privacidad app facebook webcursos

### DIFF
--- a/faq.php
+++ b/faq.php
@@ -224,6 +224,19 @@ function dohide(num) {
 	</div>
 	<div id="separador">
 	</div>
+    <div class="titulo"> POLÍTICA DE PRIVACIDAD WEBCURSOS.UAI/FACEBOOK
+	</div>
+  <div class="resumen"><b>GENERAL</b><br>
+      La Universidad Adolfo Ibáñez y WebcursosUAI se reserva el derecho a modificar la presente política de privacidad y será responsabilidad del usuario la lectura y acatamiento de esta cada vez que utilize nuestras aplicaciones.<br>
+      <br>
+      <b>Cómo usamos y protejemos el uso de tú información.</b><br>
+      La aplicación de Webcursos en Facebook sólo requerirá información personal a través de los formularios de cuentas alojados en webcursos.uai.cl. La entrega de esta información será voluntaria y con el único fin de enlazar las cuentas entre webcursos y facebook.<br><br>
+      WebcursosUAI utilizará los datos enviados por los usuarios con el exclusivo fin de utilizarlos en estudios demográficos/académicos en relación al programa académico de la Universidad Adolfo Ibáñez. Webcursos entregará la opción al visitante de desincribirse de la nómina de contacto a la que fue agregado al momento de completar el formulario.<br>
+      <br>
+  La Universidad Adolfo Ibáñez y WebcursosUAI, no entrega a terceros la información recopilada de los usuarios. No se comunicará ni transferirá a terceros los datos personales de sus usuarios. No obstante lo anterior, en caso de ser requerido judicialmente se hará entrega de la información solicitada.<br><br>
+  Todos los derechos referidos a webcursos.uai.cl y sus contenidos, incluidos los de propiedad intelectual, pertenecen a la Universidad Adolfo Ibáñez. Al acceder a la plataforma, el visitante tendrá derecho a revisar toda la información que esté disponible en él, sólo pudiendo utilizarla para fines particulares y no comerciales. Sin perjuicio de lo anterior, la universidad no se hace responsable por la veracidad o exactitud de la información contenida en los enlaces a otros sitios Web o que haya sido entregada por terceros. La Universidad Adolfo Ibáñez y Webcursos UAI autoriza la utilización o reproducción total o parcial de los contenidos e información de su portal, indicando claramente su fuente u origen.</div>
+    <div id="separador">
+	</div>
 	<div id="container2">
 		<div class="atras">
 			<a href="index.php">
@@ -232,7 +245,7 @@ function dohide(num) {
 	</div>
 </div>
 <div id="foot">
-	<div class="footer">&copy; 2014 Universidad Adolfo Ib&aacute;&ntilde;ez</div>
+	<div class="footer">&copy; 2015 Universidad Adolfo Ib&aacute;&ntilde;ez</div>
 	<div id="social">
 		<div class="facebook">
 			<a href="https://www.facebook.com/u.adolfo.ibanez">


### PR DESCRIPTION
Envio los cambios que se hicieron para agregar las políticas de privacidad que Facebook pedía para la aplicación. Estos cambios habían sido agregados directamente en producción.
